### PR TITLE
Use LuckPerms API to grant temporary queue priority

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 
 dependencies {
     compileOnly("io.papermc.paper:paper-api:1.20.6-R0.1-SNAPSHOT")
+    compileOnly("net.luckperms:api:5.4")
 }
 
 def targetJavaVersion = 21

--- a/src/main/java/org/modernbeta/PistonQueueRejoin.java
+++ b/src/main/java/org/modernbeta/PistonQueueRejoin.java
@@ -1,13 +1,26 @@
 package org.modernbeta;
 
+import net.luckperms.api.LuckPerms;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class PistonQueueRejoin extends JavaPlugin implements Listener {
+    private LuckPerms luckPerms;
+
     @Override
     public void onEnable() {
+        RegisteredServiceProvider<LuckPerms> provider =
+            getServer().getServicesManager().getRegistration(LuckPerms.class);
+        if (provider == null) {
+            getLogger().severe("Couldn't get LuckPerms API provider!");
+            getServer().getPluginManager().disablePlugin(this);
+            return;
+        } else
+            luckPerms = provider.getProvider();
+
         getServer().getPluginManager().registerEvents(this, this);
     }
 

--- a/src/main/java/org/modernbeta/PistonQueueRejoin.java
+++ b/src/main/java/org/modernbeta/PistonQueueRejoin.java
@@ -1,11 +1,19 @@
 package org.modernbeta;
 
 import net.luckperms.api.LuckPerms;
+import net.luckperms.api.model.data.TemporaryNodeMergeStrategy;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.model.user.UserManager;
+import net.luckperms.api.node.Node;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 public final class PistonQueueRejoin extends JavaPlugin implements Listener {
     private LuckPerms luckPerms;
@@ -26,11 +34,19 @@ public final class PistonQueueRejoin extends JavaPlugin implements Listener {
 
     @EventHandler(ignoreCancelled = true)
     public void onPlayerQuit(PlayerQuitEvent event) {
-        String player = event.getPlayer().getName();
-        String commandRemove = "lp user " + player + " permission unsettemp queue.priority";
-        String command = "lp user " + player + " permission settemp queue.priority true 2min";
-        getServer().dispatchCommand(getServer().getConsoleSender(), commandRemove);
-        getServer().dispatchCommand(getServer().getConsoleSender(), command);
+        Player player = event.getPlayer();
+        UserManager userManager = luckPerms.getUserManager();
+        CompletableFuture<User> userFuture = userManager.loadUser(event.getPlayer().getUniqueId());
+        Node node = Node.builder("queue.priority")
+                .expiry(2, TimeUnit.MINUTES)
+                .build();
+
+        getLogger().info("Giving " + player.getName()  + " temporary queue priority");
+        userFuture.thenAcceptAsync(user -> {
+            user.data().add(node,
+                TemporaryNodeMergeStrategy.REPLACE_EXISTING_IF_DURATION_LONGER);
+            userManager.saveUser(user);
+        });
     }
 
 }

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -2,3 +2,7 @@ name: PistonQueueRejoin
 version: '0.1.0'
 main: org.modernbeta.PistonQueueRejoin
 api-version: '1.20'
+dependencies:
+  server:
+    LuckPerms:
+      load: BEFORE


### PR DESCRIPTION
Instead of using commands, this PR changes `onPlayerQuit` to use the LuckPerms API to grant temporary queue priority.

- Add LuckPerms API dependency (84ee40e38264ad085e96f4ddf8b3560948b41eb4 & e6bb0e929fd64bdf6eb2b729c8c7e8c9d61c4fe9)
- Requires LuckPerms to load before this plugin (66eced25555c8852ee4babfd4bce0c8f89fdd827)
- Use LuckPerms API to grant temporary queue priority (9be30ade2e012f807a88963d75fae7b5c80fb70a)

Instead of removing the permission then re-granting it, I use `REPLACE_EXISTING_IF_DURATION_LONGER` which will automatically extend the temporary permission’s lifespan if the player already has it.